### PR TITLE
Updating thor to 1.2.1 used by Debian Bookworm

### DIFF
--- a/deb-s3.gemspec
+++ b/deb-s3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency "thor",    "~> 1.0.1"
+  gem.add_dependency "thor",    "~> 1.2.1"
   gem.add_dependency "aws-sdk-s3", "~> 1"
   gem.add_development_dependency "minitest", "~> 5"
   gem.add_development_dependency "rake", "~> 11"


### PR DESCRIPTION
Upgrading 'thor' dependency to fix the Bookworm deb-s3 build error:
```
Could not find 'thor' (~> 1.0.1) - did find: [thor-1.2.1]
```
